### PR TITLE
Fix encoding integers

### DIFF
--- a/src/asn1_types/boolean.rs
+++ b/src/asn1_types/boolean.rs
@@ -54,7 +54,7 @@ impl<'a, 'b> TryFrom<&'b Any<'a>> for Boolean {
     }
 }
 
-impl<'a> CheckDerConstraints for Boolean {
+impl CheckDerConstraints for Boolean {
     fn check_constraints(any: &Any) -> Result<()> {
         let c = any.data[0];
         // X.690 section 11.1
@@ -67,7 +67,7 @@ impl<'a> CheckDerConstraints for Boolean {
 
 impl DerAutoDerive for Boolean {}
 
-impl<'a> Tagged for Boolean {
+impl Tagged for Boolean {
     const TAG: Tag = Tag::Boolean;
 }
 
@@ -112,7 +112,7 @@ impl<'a, 'b> TryFrom<&'b Any<'a>> for bool {
     }
 }
 
-impl<'a> CheckDerConstraints for bool {
+impl CheckDerConstraints for bool {
     fn check_constraints(any: &Any) -> Result<()> {
         let c = any.data[0];
         // X.690 section 11.1
@@ -125,7 +125,7 @@ impl<'a> CheckDerConstraints for bool {
 
 impl DerAutoDerive for bool {}
 
-impl<'a> Tagged for bool {
+impl Tagged for bool {
     const TAG: Tag = Tag::Boolean;
 }
 

--- a/src/asn1_types/end_of_content.rs
+++ b/src/asn1_types/end_of_content.rs
@@ -36,7 +36,7 @@ impl<'a, 'b> TryFrom<&'b Any<'a>> for EndOfContent {
     }
 }
 
-impl<'a> Tagged for EndOfContent {
+impl Tagged for EndOfContent {
     const TAG: Tag = Tag::EndOfContent;
 }
 

--- a/src/asn1_types/generalizedtime.rs
+++ b/src/asn1_types/generalizedtime.rs
@@ -226,7 +226,7 @@ impl fmt::Display for GeneralizedTime {
     }
 }
 
-impl<'a> CheckDerConstraints for GeneralizedTime {
+impl CheckDerConstraints for GeneralizedTime {
     fn check_constraints(any: &Any) -> Result<()> {
         // X.690 section 11.7.1: The encoding shall terminate with a "Z"
         if any.data.last() != Some(&b'Z') {
@@ -244,7 +244,7 @@ impl<'a> CheckDerConstraints for GeneralizedTime {
 
 impl DerAutoDerive for GeneralizedTime {}
 
-impl<'a> Tagged for GeneralizedTime {
+impl Tagged for GeneralizedTime {
     const TAG: Tag = Tag::GeneralizedTime;
 }
 
@@ -286,7 +286,7 @@ impl ToDer for GeneralizedTime {
             Some(v) => format!(".{}", v),
         };
         let num_digits = fractional.len();
-        let _ = write!(
+        write!(
             writer,
             "{:04}{:02}{:02}{:02}{:02}{:02}{}Z",
             self.0.year,

--- a/src/asn1_types/integer.rs
+++ b/src/asn1_types/integer.rs
@@ -107,7 +107,7 @@ macro_rules! impl_int {
             }
         }
 
-        impl<'a> CheckDerConstraints for $int {
+        impl CheckDerConstraints for $int {
             fn check_constraints(any: &Any) -> Result<()> {
                 check_der_int_constraints(any)
             }
@@ -163,7 +163,7 @@ macro_rules! impl_uint {
                 Ok(result)
             }
         }
-        impl<'a> CheckDerConstraints for $ty {
+        impl CheckDerConstraints for $ty {
             fn check_constraints(any: &Any) -> Result<()> {
                 check_der_int_constraints(any)
             }

--- a/src/asn1_types/null.rs
+++ b/src/asn1_types/null.rs
@@ -39,7 +39,7 @@ impl CheckDerConstraints for Null {
 
 impl DerAutoDerive for Null {}
 
-impl<'a> Tagged for Null {
+impl Tagged for Null {
     const TAG: Tag = Tag::Null;
 }
 
@@ -71,7 +71,7 @@ impl<'a> TryFrom<Any<'a>> for () {
     }
 }
 
-impl<'a> CheckDerConstraints for () {
+impl CheckDerConstraints for () {
     fn check_constraints(_any: &Any) -> Result<()> {
         Ok(())
     }
@@ -79,7 +79,7 @@ impl<'a> CheckDerConstraints for () {
 
 impl DerAutoDerive for () {}
 
-impl<'a> Tagged for () {
+impl Tagged for () {
     const TAG: Tag = Tag::Null;
 }
 

--- a/src/asn1_types/oid.rs
+++ b/src/asn1_types/oid.rs
@@ -5,7 +5,8 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::{
-    convert::TryFrom, fmt, iter::FusedIterator, marker::PhantomData, ops::Shl, str::FromStr,
+    convert::TryFrom, fmt, fmt::Write, iter::FusedIterator, marker::PhantomData, ops::Shl,
+    str::FromStr,
 };
 
 #[cfg(feature = "bigint")]
@@ -224,7 +225,7 @@ impl<'a> Oid<'a> {
         } else {
             let mut ret = String::with_capacity(self.asn1.len() * 3);
             for (i, o) in self.asn1.iter().enumerate() {
-                ret.push_str(&format!("{:02x}", o));
+                let _ = write!(ret, "{:02x}", o);
                 if i + 1 != self.asn1.len() {
                     ret.push(' ');
                 }

--- a/src/asn1_types/real.rs
+++ b/src/asn1_types/real.rs
@@ -272,7 +272,7 @@ impl<'a> TryFrom<Any<'a>> for Real {
     }
 }
 
-impl<'a> CheckDerConstraints for Real {
+impl CheckDerConstraints for Real {
     fn check_constraints(any: &Any) -> Result<()> {
         any.header.assert_primitive()?;
         any.header.length.assert_definite()?;

--- a/src/asn1_types/real/f32.rs
+++ b/src/asn1_types/real/f32.rs
@@ -12,7 +12,7 @@ impl<'a> TryFrom<Any<'a>> for f32 {
     }
 }
 
-impl<'a> CheckDerConstraints for f32 {
+impl CheckDerConstraints for f32 {
     fn check_constraints(any: &Any) -> Result<()> {
         any.header.assert_primitive()?;
         any.header.length.assert_definite()?;

--- a/src/asn1_types/real/f64.rs
+++ b/src/asn1_types/real/f64.rs
@@ -12,7 +12,7 @@ impl<'a> TryFrom<Any<'a>> for f64 {
     }
 }
 
-impl<'a> CheckDerConstraints for f64 {
+impl CheckDerConstraints for f64 {
     fn check_constraints(any: &Any) -> Result<()> {
         any.header.assert_primitive()?;
         any.header.length.assert_definite()?;

--- a/src/asn1_types/sequence.rs
+++ b/src/asn1_types/sequence.rs
@@ -286,7 +286,7 @@ impl<'a> ToStatic for Sequence<'a> {
     }
 }
 
-impl<'a, T, U> ToStatic for Vec<T>
+impl<T, U> ToStatic for Vec<T>
 where
     T: ToStatic<Owned = U>,
     U: 'static,

--- a/src/asn1_types/sequence/sequence_of.rs
+++ b/src/asn1_types/sequence/sequence_of.rs
@@ -57,7 +57,7 @@ impl<T> SequenceOf<T> {
     }
 }
 
-impl<'a, T> AsRef<[T]> for SequenceOf<T> {
+impl<T> AsRef<[T]> for SequenceOf<T> {
     fn as_ref(&self) -> &[T] {
         &self.items
     }

--- a/src/asn1_types/set/set_of.rs
+++ b/src/asn1_types/set/set_of.rs
@@ -57,7 +57,7 @@ impl<T> SetOf<T> {
     }
 }
 
-impl<'a, T> AsRef<[T]> for SetOf<T> {
+impl<T> AsRef<[T]> for SetOf<T> {
     fn as_ref(&self) -> &[T] {
         &self.items
     }

--- a/src/asn1_types/strings.rs
+++ b/src/asn1_types/strings.rs
@@ -105,7 +105,7 @@ macro_rules! asn1_string {
             type Error = $crate::Error;
 
             fn try_from(any: &'b $crate::Any<'a>) -> $crate::Result<$name<'a>> {
-                use crate::traits::Tagged;
+                use $crate::traits::Tagged;
                 use alloc::borrow::Cow;
                 any.tag().assert_eq(Self::TAG)?;
                 <$name>::test_valid_charset(any.data)?;

--- a/src/asn1_types/strings/string.rs
+++ b/src/asn1_types/strings/string.rs
@@ -20,7 +20,7 @@ impl<'a, 'b> TryFrom<&'b Any<'a>> for String {
     }
 }
 
-impl<'a> CheckDerConstraints for String {
+impl CheckDerConstraints for String {
     fn check_constraints(any: &Any) -> Result<()> {
         // X.690 section 10.2
         any.header.assert_primitive()?;

--- a/src/asn1_types/tagged/explicit.rs
+++ b/src/asn1_types/tagged/explicit.rs
@@ -64,7 +64,7 @@ where
     }
 }
 
-impl<'a, T, E, const CLASS: u8, const TAG: u32> CheckDerConstraints
+impl<T, E, const CLASS: u8, const TAG: u32> CheckDerConstraints
     for TaggedValue<T, E, Explicit, CLASS, TAG>
 where
     T: CheckDerConstraints,

--- a/src/asn1_types/tagged/implicit.rs
+++ b/src/asn1_types/tagged/implicit.rs
@@ -79,7 +79,7 @@ where
     }
 }
 
-impl<'a, T, E, const CLASS: u8, const TAG: u32> CheckDerConstraints
+impl<T, E, const CLASS: u8, const TAG: u32> CheckDerConstraints
     for TaggedValue<T, E, Implicit, CLASS, TAG>
 where
     T: CheckDerConstraints,

--- a/src/asn1_types/utctime.rs
+++ b/src/asn1_types/utctime.rs
@@ -211,7 +211,7 @@ impl ToDer for UtcTime {
     }
 
     fn write_der_content(&self, writer: &mut dyn std::io::Write) -> SerializeResult<usize> {
-        let _ = write!(
+        write!(
             writer,
             "{:02}{:02}{:02}{:02}{:02}{:02}Z",
             self.0.year, self.0.month, self.0.day, self.0.hour, self.0.minute, self.0.second,

--- a/tests/to_der.rs
+++ b/tests/to_der.rs
@@ -218,7 +218,7 @@ fn to_der_integer() {
     // signed i32 (> 0)
     encode_decode_assert_int(4, &[0x02, 0x01, 0x04]);
     // signed i32 (< 0)
-    encode_decode_assert_int(-4, &[0x02, 0x05, 0x00, 0xff, 0xff, 0xff, 0xfc]);
+    encode_decode_assert_int(-4, &[0x02, 0x01, 0xfc]);
 }
 
 #[test]


### PR DESCRIPTION
When encoding unsigned integers we must prefix the representation with
an extra 0x00 if the high bit is set. Otherwise it would be interpreted
as a negative number.

Additionally we should remove any redundant leading 0xFF and 0x00 bytes.

Before this patch the code would mixed up these encodings. It would
always add an 0x00 to signed negative numbers and remove leading 0x00
for positive numbers.

This patch introduces encode tests akin to the decode tests for
integers and fixes the implementations for encoding.

Additionally we fixed to tests that tested for this wrong behaviour.