### PR TITLE
Fix receiver lifetimes in `Any` methods.

### DIFF
--- a/src/asn1_types/any.rs
+++ b/src/asn1_types/any.rs
@@ -73,12 +73,12 @@ impl<'a> Any<'a> {
 
     /// Get the bytes representation of the *content*
     #[inline]
-    pub fn as_bytes(&'a self) -> &'a [u8] {
+    pub fn as_bytes(&self) -> &'a [u8] {
         self.data
     }
 
     #[inline]
-    pub fn parse_ber<T>(&'a self) -> ParseResult<'a, T>
+    pub fn parse_ber<T>(&self) -> ParseResult<'a, T>
     where
         T: FromBer<'a>,
     {
@@ -134,7 +134,7 @@ impl<'a> Any<'a> {
     }
 
     #[inline]
-    pub fn parse_der<T>(&'a self) -> ParseResult<'a, T>
+    pub fn parse_der<T>(&self) -> ParseResult<'a, T>
     where
         T: FromDer<'a>,
     {


### PR DESCRIPTION
The lifetimes in several `Any` methods are restrictive in a manner that's unlikely intended. To resolve this, this PR makes changes of the following nature:

```diff
-    pub fn as_bytes(&'a self) -> &'a [u8] {
+    pub fn as_bytes(&self) -> &'a [u8] {
```

The prior method signature requires that the reference to receiver have the same lifetime as the internal content of `Any`. What this means is that Rust will unify the lifetime of the receiver with that of the returned content. Since the receiver _must_ have a shorter lifetime than the content, the lifetime of the returned content is shortened. This is unnecessary as there need not be _any_ restriction on the receiver's lifetime.

