### PR TITLE
Updates the displaydoc version to 0.2.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ asn1-rs-derive = { version="0.5", path="./derive" }
 asn1-rs-impl = { version="0.2", path="./impl" }
 bitvec = { version="1.0", optional=true }
 cookie-factory = { version="0.3.0", optional=true }
-displaydoc = "0.2.2"
+displaydoc = "0.2.4"
 nom = { version="7.0", default_features=false, features=["std"] }
 num-bigint = { version = "0.4", optional = true }
 num-traits = "0.2.14"


### PR DESCRIPTION
Displaydoc appears like it hasn't been updated for awhile. Just wanted to see if we could update it.