### PR TITLE
Add debug/trace features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,9 +28,16 @@ jobs:
         with:
           command: check
 
-  test:
-    name: Test Suite
+  check_features:
+    name: Check features
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features:
+          - --features=default
+          - --all-features
+          - --features=bigint,serialize,debug
+          - --features=bigint,serialize,trace
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -38,10 +45,12 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - name: Cargo update
+        run: cargo update
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features
+          args: ${{ matrix.features }}
 
   no_std:
     name: no-std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,13 +42,16 @@ default = ["std"]
 bigint = ["num-bigint"]
 bits = ["bitvec"]
 datetime = ["time"]
+debug = ["colored"]
 serialize = ["cookie-factory"]
 std = []
+trace = ["debug"]
 
 [dependencies]
 asn1-rs-derive = { version="0.5", path="./derive" }
 asn1-rs-impl = { version="0.2", path="./impl" }
 bitvec = { version="1.0", optional=true }
+colored = { version="2.0", optional=true }
 cookie-factory = { version="0.3.0", optional=true }
 displaydoc = "0.2.2"
 nom = { version="7.0", default_features=false, features=["std"] }

--- a/src/asn1_types/any.rs
+++ b/src/asn1_types/any.rs
@@ -1,6 +1,7 @@
 use crate::ber::*;
 use crate::*;
 use alloc::borrow::Cow;
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 use core::convert::{TryFrom, TryInto};
 
@@ -103,10 +104,10 @@ impl<'a> Any<'a> {
         let (rem, any) = Any::from_ber(bytes).map_err(Err::convert)?;
         any.tag()
             .assert_eq(Tag(tag))
-            .map_err(|e| nom::Err::Error(e.into()))?;
+            .map_err(|e| Err::Error(e.into()))?;
         any.class()
             .assert_eq(class)
-            .map_err(|e| nom::Err::Error(e.into()))?;
+            .map_err(|e| Err::Error(e.into()))?;
         let (_, res) = op(any.data)?;
         Ok((rem, res))
     }
@@ -127,10 +128,10 @@ impl<'a> Any<'a> {
         let (rem, any) = Any::from_der(bytes).map_err(Err::convert)?;
         any.tag()
             .assert_eq(Tag(tag))
-            .map_err(|e| nom::Err::Error(e.into()))?;
+            .map_err(|e| Err::Error(e.into()))?;
         any.class()
             .assert_eq(class)
-            .map_err(|e| nom::Err::Error(e.into()))?;
+            .map_err(|e| Err::Error(e.into()))?;
         let (_, res) = op(any.data)?;
         Ok((rem, res))
     }

--- a/src/asn1_types/generalizedtime.rs
+++ b/src/asn1_types/generalizedtime.rs
@@ -1,6 +1,6 @@
-use crate::datetime::decode_decimal;
 use crate::*;
 use alloc::format;
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 use core::convert::TryFrom;
 use core::fmt;

--- a/src/asn1_types/object_descriptor.rs
+++ b/src/asn1_types/object_descriptor.rs
@@ -1,5 +1,6 @@
 use crate::{asn1_string, TestValidCharset};
 use crate::{Error, Result};
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 
 // X.680 section 44.3

--- a/src/asn1_types/oid.rs
+++ b/src/asn1_types/oid.rs
@@ -2,14 +2,13 @@ use crate::*;
 use alloc::borrow::Cow;
 #[cfg(not(feature = "std"))]
 use alloc::format;
+#[cfg(not(feature = "std"))]
 use alloc::string::{String, ToString};
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::{
     convert::TryFrom, fmt, iter::FusedIterator, marker::PhantomData, ops::Shl, str::FromStr,
 };
-
-#[cfg(feature = "bigint")]
-use num_bigint::BigUint;
 use num_traits::Num;
 
 /// An error for OID parsing functions.

--- a/src/asn1_types/real.rs
+++ b/src/asn1_types/real.rs
@@ -1,7 +1,6 @@
 use crate::*;
 use alloc::format;
 use core::convert::TryFrom;
-use nom::Needed;
 
 mod f32;
 mod f64;

--- a/src/asn1_types/sequence.rs
+++ b/src/asn1_types/sequence.rs
@@ -1,5 +1,6 @@
 use crate::*;
 use alloc::borrow::Cow;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 
@@ -179,7 +180,7 @@ impl<'a> Sequence<'a> {
     {
         match self.content {
             Cow::Borrowed(b) => f(b),
-            _ => Err(nom::Err::Error(Error::LifetimeError.into())),
+            _ => Err(Err::Error(Error::LifetimeError.into())),
         }
     }
 

--- a/src/asn1_types/sequence/sequence_of.rs
+++ b/src/asn1_types/sequence/sequence_of.rs
@@ -4,6 +4,8 @@ use core::convert::TryFrom;
 use core::iter::FromIterator;
 use core::ops::{Deref, DerefMut};
 
+use self::debug::trace;
+
 /// The `SEQUENCE OF` object is an ordered list of homogeneous types.
 ///
 /// This type implements `Deref<Target = [T]>` and `DerefMut<Target = [T]>`, so all methods
@@ -131,7 +133,8 @@ where
     E: From<Error>,
 {
     fn from_der(bytes: &'a [u8]) -> ParseResult<Self, E> {
-        let (rem, any) = Any::from_der(bytes).map_err(Err::convert)?;
+        let (rem, any) =
+            trace(core::any::type_name::<Self>(), parse_der_any, bytes).map_err(Err::convert)?;
         any.header
             .assert_tag(Self::TAG)
             .map_err(|e| nom::Err::Error(e.into()))?;

--- a/src/asn1_types/sequence/sequence_of.rs
+++ b/src/asn1_types/sequence/sequence_of.rs
@@ -1,4 +1,5 @@
 use crate::*;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use core::fmt::{Debug, Display};
@@ -142,10 +143,10 @@ where
                     .map_err(Err::convert)?;
                 any.header
                     .assert_tag(Self::TAG)
-                    .map_err(|e| nom::Err::Error(e.into()))?;
+                    .map_err(|e| Err::Error(e.into()))?;
                 let items = SequenceIterator::<T, DerParser, E>::new(any.data)
                     .collect::<Result<Vec<T>, E>>()
-                    .map_err(nom::Err::Error)?;
+                    .map_err(Err::Error)?;
                 Ok((rem, SequenceOf::new(items)))
             },
             bytes,

--- a/src/asn1_types/sequence/vec.rs
+++ b/src/asn1_types/sequence/vec.rs
@@ -2,6 +2,8 @@ use crate::*;
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 
+use self::debug::trace;
+
 // // XXX this compiles but requires bound TryFrom :/
 // impl<'a, 'b, T> TryFrom<&'b Any<'a>> for Vec<T>
 // where
@@ -94,7 +96,8 @@ where
     E: From<Error>,
 {
     fn from_der(bytes: &'a [u8]) -> ParseResult<Self, E> {
-        let (rem, any) = Any::from_der(bytes).map_err(Err::convert)?;
+        let (rem, any) =
+            trace(core::any::type_name::<Self>(), parse_der_any, bytes).map_err(Err::convert)?;
         any.header
             .assert_tag(Self::TAG)
             .map_err(|e| nom::Err::Error(e.into()))?;

--- a/src/asn1_types/sequence/vec.rs
+++ b/src/asn1_types/sequence/vec.rs
@@ -1,4 +1,5 @@
 use crate::*;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use core::fmt::Debug;
@@ -121,10 +122,10 @@ where
                     .map_err(Err::convert)?;
                 any.header
                     .assert_tag(Self::TAG)
-                    .map_err(|e| nom::Err::Error(e.into()))?;
+                    .map_err(|e| Err::Error(e.into()))?;
                 let v = SequenceIterator::<T, DerParser, E>::new(any.data)
                     .collect::<Result<Vec<T>, E>>()
-                    .map_err(nom::Err::Error)?;
+                    .map_err(Err::Error)?;
                 Ok((rem, v))
             },
             bytes,

--- a/src/asn1_types/set.rs
+++ b/src/asn1_types/set.rs
@@ -1,5 +1,6 @@
 use crate::*;
 use alloc::borrow::Cow;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 
@@ -180,7 +181,7 @@ impl<'a> Set<'a> {
     {
         match self.content {
             Cow::Borrowed(b) => f(b),
-            _ => Err(nom::Err::Error(Error::LifetimeError.into())),
+            _ => Err(Err::Error(Error::LifetimeError.into())),
         }
     }
 

--- a/src/asn1_types/set/btreeset.rs
+++ b/src/asn1_types/set/btreeset.rs
@@ -62,13 +62,13 @@ where
                     .map_err(Err::convert)?;
                 any.tag()
                     .assert_eq(Self::TAG)
-                    .map_err(|e| nom::Err::Error(e.into()))?;
+                    .map_err(|e| Err::Error(e.into()))?;
                 any.header
                     .assert_constructed()
-                    .map_err(|e| nom::Err::Error(e.into()))?;
+                    .map_err(|e| Err::Error(e.into()))?;
                 let items = SetIterator::<T, DerParser, E>::new(any.data)
                     .collect::<Result<BTreeSet<T>, E>>()
-                    .map_err(nom::Err::Error)?;
+                    .map_err(Err::Error)?;
                 Ok((rem, items))
             },
             bytes,

--- a/src/asn1_types/set/btreeset.rs
+++ b/src/asn1_types/set/btreeset.rs
@@ -2,6 +2,8 @@ use crate::*;
 use alloc::collections::BTreeSet;
 use core::convert::TryFrom;
 
+use self::debug::trace;
+
 impl<T> Tagged for BTreeSet<T> {
     const TAG: Tag = Tag::Set;
 }
@@ -44,7 +46,8 @@ where
     E: From<Error>,
 {
     fn from_der(bytes: &'a [u8]) -> ParseResult<'a, Self, E> {
-        let (rem, any) = Any::from_der(bytes).map_err(Err::convert)?;
+        let (rem, any) =
+            trace(core::any::type_name::<Self>(), Any::from_der, bytes).map_err(Err::convert)?;
         any.tag()
             .assert_eq(Self::TAG)
             .map_err(|e| nom::Err::Error(e.into()))?;

--- a/src/asn1_types/set/hashset.rs
+++ b/src/asn1_types/set/hashset.rs
@@ -4,6 +4,8 @@ use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::hash::Hash;
 
+use self::debug::trace;
+
 impl<T> Tagged for HashSet<T> {
     const TAG: Tag = Tag::Set;
 }
@@ -46,7 +48,8 @@ where
     E: From<Error>,
 {
     fn from_der(bytes: &'a [u8]) -> ParseResult<'a, Self, E> {
-        let (rem, any) = Any::from_der(bytes).map_err(Err::convert)?;
+        let (rem, any) =
+            trace(core::any::type_name::<Self>(), Any::from_der, bytes).map_err(Err::convert)?;
         any.tag()
             .assert_eq(Self::TAG)
             .map_err(|e| nom::Err::Error(e.into()))?;

--- a/src/asn1_types/set/hashset.rs
+++ b/src/asn1_types/set/hashset.rs
@@ -57,13 +57,13 @@ where
                     .map_err(Err::convert)?;
                 any.tag()
                     .assert_eq(Self::TAG)
-                    .map_err(|e| nom::Err::Error(e.into()))?;
+                    .map_err(|e| Err::Error(e.into()))?;
                 any.header
                     .assert_constructed()
-                    .map_err(|e| nom::Err::Error(e.into()))?;
+                    .map_err(|e| Err::Error(e.into()))?;
                 let items = SetIterator::<T, DerParser, E>::new(any.data)
                     .collect::<Result<HashSet<T>, E>>()
-                    .map_err(nom::Err::Error)?;
+                    .map_err(Err::Error)?;
                 Ok((rem, items))
             },
             bytes,

--- a/src/asn1_types/set/set_of.rs
+++ b/src/asn1_types/set/set_of.rs
@@ -4,6 +4,8 @@ use core::convert::TryFrom;
 use core::iter::FromIterator;
 use core::ops::{Deref, DerefMut};
 
+use self::debug::trace;
+
 /// The `SET OF` object is an unordered list of homogeneous types.
 ///
 /// This type implements `Deref<Target = [T]>` and `DerefMut<Target = [T]>`, so all methods
@@ -131,7 +133,8 @@ where
     E: From<Error>,
 {
     fn from_der(bytes: &'a [u8]) -> ParseResult<Self, E> {
-        let (rem, any) = Any::from_der(bytes).map_err(Err::convert)?;
+        let (rem, any) =
+            trace(core::any::type_name::<Self>(), Any::from_der, bytes).map_err(Err::convert)?;
         any.header
             .assert_tag(Self::TAG)
             .map_err(|e| nom::Err::Error(e.into()))?;

--- a/src/asn1_types/set/set_of.rs
+++ b/src/asn1_types/set/set_of.rs
@@ -1,10 +1,11 @@
 use crate::*;
 use alloc::vec::Vec;
 use core::convert::TryFrom;
+use core::fmt::{Debug, Display};
 use core::iter::FromIterator;
 use core::ops::{Deref, DerefMut};
 
-use self::debug::trace;
+use self::debug::{trace, trace_generic};
 
 /// The `SET OF` object is an unordered list of homogeneous types.
 ///
@@ -130,18 +131,25 @@ where
 impl<'a, T, E> FromDer<'a, E> for SetOf<T>
 where
     T: FromDer<'a, E>,
-    E: From<Error>,
+    E: From<Error> + Display + Debug,
 {
     fn from_der(bytes: &'a [u8]) -> ParseResult<Self, E> {
-        let (rem, any) =
-            trace(core::any::type_name::<Self>(), Any::from_der, bytes).map_err(Err::convert)?;
-        any.header
-            .assert_tag(Self::TAG)
-            .map_err(|e| nom::Err::Error(e.into()))?;
-        let items = SetIterator::<T, DerParser, E>::new(any.data)
-            .collect::<Result<Vec<T>, E>>()
-            .map_err(nom::Err::Error)?;
-        Ok((rem, SetOf::new(items)))
+        trace_generic(
+            core::any::type_name::<Self>(),
+            "SetOf::from_der",
+            |bytes| {
+                let (rem, any) = trace(core::any::type_name::<Self>(), Any::from_der, bytes)
+                    .map_err(Err::convert)?;
+                any.header
+                    .assert_tag(Self::TAG)
+                    .map_err(|e| nom::Err::Error(e.into()))?;
+                let items = SetIterator::<T, DerParser, E>::new(any.data)
+                    .collect::<Result<Vec<T>, E>>()
+                    .map_err(nom::Err::Error)?;
+                Ok((rem, SetOf::new(items)))
+            },
+            bytes,
+        )
     }
 }
 

--- a/src/asn1_types/set/set_of.rs
+++ b/src/asn1_types/set/set_of.rs
@@ -1,4 +1,5 @@
 use crate::*;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use core::fmt::{Debug, Display};
@@ -142,10 +143,10 @@ where
                     .map_err(Err::convert)?;
                 any.header
                     .assert_tag(Self::TAG)
-                    .map_err(|e| nom::Err::Error(e.into()))?;
+                    .map_err(|e| Err::Error(e.into()))?;
                 let items = SetIterator::<T, DerParser, E>::new(any.data)
                     .collect::<Result<Vec<T>, E>>()
-                    .map_err(nom::Err::Error)?;
+                    .map_err(Err::Error)?;
                 Ok((rem, SetOf::new(items)))
             },
             bytes,

--- a/src/asn1_types/strings/bmpstring.rs
+++ b/src/asn1_types/strings/bmpstring.rs
@@ -3,7 +3,9 @@
 
 use crate::*;
 use alloc::borrow::Cow;
+#[cfg(not(feature = "std"))]
 use alloc::string::{String, ToString};
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 /// ASN.1 `BMPSTRING` type
@@ -42,7 +44,7 @@ impl<'a> From<&'a str> for BmpString<'a> {
 impl From<String> for BmpString<'_> {
     fn from(s: String) -> Self {
         Self {
-            data: alloc::borrow::Cow::Owned(s),
+            data: Cow::Owned(s),
         }
     }
 }

--- a/src/asn1_types/strings/generalstring.rs
+++ b/src/asn1_types/strings/generalstring.rs
@@ -1,5 +1,6 @@
 use crate::{asn1_string, TestValidCharset};
 use crate::{Error, Result};
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 
 asn1_string!(GeneralString);

--- a/src/asn1_types/strings/graphicstring.rs
+++ b/src/asn1_types/strings/graphicstring.rs
@@ -1,5 +1,6 @@
 use crate::{asn1_string, TestValidCharset};
 use crate::{Error, Result};
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 
 asn1_string!(GraphicString);

--- a/src/asn1_types/strings/ia5string.rs
+++ b/src/asn1_types/strings/ia5string.rs
@@ -1,5 +1,6 @@
 use crate::{asn1_string, TestValidCharset};
 use crate::{Error, Result};
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 
 asn1_string!(Ia5String);

--- a/src/asn1_types/strings/numericstring.rs
+++ b/src/asn1_types/strings/numericstring.rs
@@ -1,5 +1,6 @@
 use crate::{asn1_string, TestValidCharset};
 use crate::{Error, Result};
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 
 asn1_string!(NumericString);

--- a/src/asn1_types/strings/printablestring.rs
+++ b/src/asn1_types/strings/printablestring.rs
@@ -1,5 +1,6 @@
 use crate::{asn1_string, TestValidCharset};
 use crate::{Error, Result};
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 
 asn1_string!(PrintableString);

--- a/src/asn1_types/strings/string.rs
+++ b/src/asn1_types/strings/string.rs
@@ -1,4 +1,5 @@
 use crate::*;
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 use core::convert::TryFrom;
 

--- a/src/asn1_types/strings/teletexstring.rs
+++ b/src/asn1_types/strings/teletexstring.rs
@@ -1,5 +1,6 @@
 use crate::{asn1_string, TestValidCharset};
 use crate::{Error, Result};
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 
 asn1_string!(TeletexString);

--- a/src/asn1_types/strings/universalstring.rs
+++ b/src/asn1_types/strings/universalstring.rs
@@ -3,7 +3,9 @@
 
 use crate::*;
 use alloc::borrow::Cow;
+#[cfg(not(feature = "std"))]
 use alloc::string::{String, ToString};
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use core::iter::FromIterator;
@@ -43,7 +45,7 @@ impl<'a> From<&'a str> for UniversalString<'a> {
 impl From<String> for UniversalString<'_> {
     fn from(s: String) -> Self {
         Self {
-            data: alloc::borrow::Cow::Owned(s),
+            data: Cow::Owned(s),
         }
     }
 }

--- a/src/asn1_types/strings/utf8string.rs
+++ b/src/asn1_types/strings/utf8string.rs
@@ -1,6 +1,7 @@
 use crate::asn1_string;
 use crate::Result;
 use crate::TestValidCharset;
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 
 asn1_string!(Utf8String);

--- a/src/asn1_types/strings/videotexstring.rs
+++ b/src/asn1_types/strings/videotexstring.rs
@@ -1,5 +1,6 @@
 use crate::{asn1_string, TestValidCharset};
 use crate::{Error, Result};
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 
 asn1_string!(VideotexString);

--- a/src/asn1_types/strings/visiblestring.rs
+++ b/src/asn1_types/strings/visiblestring.rs
@@ -1,5 +1,6 @@
 use crate::{asn1_string, TestValidCharset};
 use crate::{Error, Result};
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 
 asn1_string!(VisibleString);

--- a/src/asn1_types/tagged/helpers.rs
+++ b/src/asn1_types/tagged/helpers.rs
@@ -34,7 +34,7 @@ where
     parse_der_container(tag, move |any: Any<'a>| {
         any.header
             .assert_tag(tag)
-            .map_err(|e| nom::Err::convert(e.into()))?;
+            .map_err(|e| Err::convert(e.into()))?;
         f(any.data, any.header)
     })
 }
@@ -51,9 +51,7 @@ where
     let tag = tag.into();
     move |i| {
         let (rem, tagged) = TaggedParser::from_der(i)?;
-        tagged
-            .assert_tag(tag)
-            .map_err(|e| nom::Err::convert(e.into()))?;
+        tagged.assert_tag(tag).map_err(|e| Err::convert(e.into()))?;
         Ok((rem, tagged))
     }
 }
@@ -73,7 +71,7 @@ where
         // verify tag of external header
         any.header
             .assert_tag(tag)
-            .map_err(|e| nom::Err::convert(e.into()))?;
+            .map_err(|e| Err::convert(e.into()))?;
         // build a fake header with the expected tag
         let Any { header, data } = any;
         let header = Header {
@@ -93,10 +91,10 @@ where
     E: ParseError<&'a [u8]> + From<Error>,
 {
     move |i: &[u8]| {
-        let (rem, any) = Any::from_der(i).map_err(nom::Err::convert)?;
+        let (rem, any) = Any::from_der(i).map_err(Err::convert)?;
         any.header
             .assert_tag(tag)
-            .map_err(|e| nom::Err::convert(e.into()))?;
+            .map_err(|e| Err::convert(e.into()))?;
         let (_, output) = f(any)?;
         Ok((rem, output))
     }

--- a/src/asn1_types/tagged/implicit.rs
+++ b/src/asn1_types/tagged/implicit.rs
@@ -74,7 +74,7 @@ where
         };
         match T::try_from(any) {
             Ok(inner) => Ok((rem, TaggedValue::implicit(inner))),
-            Err(e) => Err(nom::Err::Error(e)),
+            Err(e) => Err(Err::Error(e)),
         }
     }
 }
@@ -182,7 +182,7 @@ where
                 };
                 Ok((rem, tagged_value))
             }
-            Err(e) => Err(nom::Err::Error(e)),
+            Err(e) => Err(Err::Error(e)),
         }
     }
 }
@@ -217,7 +217,7 @@ where
             },
             data,
         };
-        T::check_constraints(&any).map_err(|e| nom::Err::Error(e.into()))?;
+        T::check_constraints(&any).map_err(|e| Err::Error(e.into()))?;
         match T::try_from(any) {
             Ok(t) => {
                 let tagged_value = TaggedParser {
@@ -228,7 +228,7 @@ where
                 };
                 Ok((rem, tagged_value))
             }
-            Err(e) => Err(nom::Err::Error(e)),
+            Err(e) => Err(Err::Error(e)),
         }
     }
 }

--- a/src/asn1_types/tagged/optional.rs
+++ b/src/asn1_types/tagged/optional.rs
@@ -1,4 +1,3 @@
-use super::{explicit::TaggedExplicit, implicit::TaggedImplicit};
 use crate::*;
 
 /// Helper object to parse TAGGED OPTIONAL types (explicit or implicit)

--- a/src/asn1_types/utctime.rs
+++ b/src/asn1_types/utctime.rs
@@ -1,4 +1,3 @@
-use crate::datetime::decode_decimal;
 use crate::*;
 use core::convert::TryFrom;
 use core::fmt;

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1,5 +1,6 @@
 use crate::{Result, Tag};
 use alloc::format;
+#[cfg(not(feature = "std"))]
 use alloc::string::ToString;
 use core::fmt;
 #[cfg(feature = "datetime")]

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -5,6 +5,7 @@ macro_rules! debug_eprintln {
     ($msg: expr, $( $args:expr ),* ) => {
         #[cfg(feature = "debug")]
         {
+            use colored::Colorize;
             let s = $msg.to_string().green();
             eprintln!("{} {}", s, format!($($args),*));
         }
@@ -16,6 +17,7 @@ macro_rules! trace_eprintln {
     ($msg: expr, $( $args:expr ),* ) => {
         #[cfg(feature = "trace")]
         {
+            use colored::Colorize;
             let s = $msg.to_string().green();
             eprintln!("{} {}", s, format!($($args),*));
         }
@@ -36,6 +38,34 @@ fn eprintln_hex_dump(bytes: &[u8], max_len: usize) {
 
 #[cfg(not(feature = "debug"))]
 #[inline]
+pub fn trace_generic<F, I, O, E>(_msg: &str, _fname: &str, f: F, input: I) -> Result<O, E>
+where
+    F: Fn(I) -> Result<O, E>,
+{
+    f(input)
+}
+
+#[cfg(feature = "debug")]
+pub fn trace_generic<F, I, O, E>(msg: &str, fname: &str, f: F, input: I) -> Result<O, E>
+where
+    F: Fn(I) -> Result<O, E>,
+    E: core::fmt::Display,
+{
+    trace_eprintln!(msg, "⤷ {}", fname);
+    let output = f(input);
+    match &output {
+        Err(e) => {
+            debug_eprintln!(msg, "↯ {} failed: {}", fname, e.to_string().red());
+        }
+        _ => {
+            debug_eprintln!(msg, "⤶ {}", fname);
+        }
+    }
+    output
+}
+
+#[cfg(not(feature = "debug"))]
+#[inline]
 pub fn trace<'a, T, E, F>(_msg: &str, f: F, input: &'a [u8]) -> ParseResult<'a, T, E>
 where
     F: Fn(&'a [u8]) -> ParseResult<'a, T, E>,
@@ -47,10 +77,7 @@ where
 pub fn trace<'a, T, E, F>(msg: &str, f: F, input: &'a [u8]) -> ParseResult<'a, T, E>
 where
     F: Fn(&'a [u8]) -> ParseResult<'a, T, E>,
-    E: core::fmt::Debug,
 {
-    use colored::Colorize;
-
     trace_eprintln!(
         msg,
         "⤷ input (len={}, type={})",
@@ -67,26 +94,69 @@ where
                 _rem.len()
             );
         }
-        Err(e) => {
-            debug_eprintln!(msg, "↯ Parsing failed: {}", e.to_string().red());
+        Err(_) => {
+            // NOTE: we do not need to print error, caller should print it
+            debug_eprintln!(msg, "↯ Parsing failed at location:");
             eprintln_hex_dump(input, 16);
         }
     }
     res
 }
 
+#[cfg(feature = "debug")]
 #[cfg(test)]
 mod tests {
-    use crate::{Any, FromDer};
+
+    use std::collections::HashSet;
+
+    use crate::*;
+    use alloc::collections::BTreeSet;
     use hex_literal::hex;
 
-    #[cfg(feature = "debug")]
+    #[test]
+    fn debug_from_ber_any() {
+        assert!(Any::from_ber(&hex!("01 01 ff")).is_ok());
+    }
+
+    #[test]
+    fn debug_from_ber_failures() {
+        // wrong type
+        eprintln!("--");
+        assert!(<Vec<u16>>::from_ber(&hex!("02 01 00")).is_err());
+    }
+
+    #[test]
+    fn debug_from_ber_sequence_indefinite() {
+        let input = &hex!("30 80 02 03 01 00 01 00 00");
+        let (rem, result) = Sequence::from_ber(input).expect("parsing failed");
+        assert_eq!(result.as_ref(), &input[2..7]);
+        assert_eq!(rem, &[]);
+        eprintln!("--");
+        let (rem, result) = <Vec<u32>>::from_ber(input).expect("parsing failed");
+        assert_eq!(&result, &[65537]);
+        assert_eq!(rem, &[]);
+    }
+
+    #[test]
+    fn debug_from_ber_sequence_of() {
+        // parsing failure (wrong type)
+        let input = &hex!("30 03 01 01 00");
+        eprintln!("--");
+        let _ = <SequenceOf<u32>>::from_ber(input).expect_err("parsing should fail");
+        eprintln!("--");
+        let _ = <Vec<u32>>::from_ber(input).expect_err("parsing should fail");
+    }
+
+    #[test]
+    fn debug_from_ber_u32() {
+        assert!(u32::from_ber(&hex!("02 01 01")).is_ok());
+    }
+
     #[test]
     fn debug_from_der_any() {
         assert!(Any::from_der(&hex!("01 01 ff")).is_ok());
     }
 
-    #[cfg(feature = "debug")]
     #[test]
     fn debug_from_der_failures() {
         use crate::Sequence;
@@ -105,17 +175,25 @@ mod tests {
         let _ = Sequence::from_der(&hex!("30 81 04 00 00"));
     }
 
-    #[cfg(feature = "debug")]
     #[test]
     fn debug_from_der_sequence() {
         // parsing OK, recursive
-        let input = &hex!("30 05 02 03 01 00 01");
+        let input = &hex!("30 08 02 03 01 00 01 02 01 01");
         let (rem, result) = <Vec<u32>>::from_der(input).expect("parsing failed");
-        assert_eq!(&result, &[65537]);
+        assert_eq!(&result, &[65537, 1]);
         assert_eq!(rem, &[]);
     }
 
-    #[cfg(feature = "debug")]
+    #[test]
+    fn debug_from_der_sequence_fail() {
+        // tag is wrong
+        let input = &hex!("31 03 01 01 44");
+        let _ = <Vec<bool>>::from_der(input).expect_err("parsing should fail");
+        // sequence is ok but contraint fails on element
+        let input = &hex!("30 03 01 01 44");
+        let _ = <Vec<bool>>::from_der(input).expect_err("parsing should fail");
+    }
+
     #[test]
     fn debug_from_der_sequence_of() {
         use crate::SequenceOf;
@@ -127,7 +205,13 @@ mod tests {
         let _ = <Vec<u32>>::from_der(input).expect_err("parsing should fail");
     }
 
-    #[cfg(feature = "debug")]
+    #[test]
+    fn debug_from_der_set_fail() {
+        // set is ok but contraint fails on element
+        let input = &hex!("31 03 01 01 44");
+        let _ = <BTreeSet<bool>>::from_der(input).expect_err("parsing should fail");
+    }
+
     #[test]
     fn debug_from_der_set_of() {
         use crate::SetOf;
@@ -139,40 +223,22 @@ mod tests {
         let _ = <SetOf<u32>>::from_der(input).expect_err("parsing should fail");
         eprintln!("--");
         let _ = <BTreeSet<u32>>::from_der(input).expect_err("parsing should fail");
+        eprintln!("--");
+        let _ = <HashSet<u32>>::from_der(input).expect_err("parsing should fail");
     }
 
-    /// Check that it is possible to implement an error without fmt::Debug
-    #[cfg(not(feature = "debug"))]
     #[test]
-    fn from_der_error_not_impl_debug() {
-        use crate::{CheckDerConstraints, DerAutoDerive};
-        use core::convert::TryFrom;
+    fn debug_from_der_string_ok() {
+        let input = &hex!("0c 0a 53 6f 6d 65 2d 53 74 61 74 65");
+        let (rem, result) = Utf8String::from_der(input).expect("parsing failed");
+        assert_eq!(result.as_ref(), "Some-State");
+        assert_eq!(rem, &[]);
+    }
 
-        struct MyError;
-
-        struct A;
-
-        impl CheckDerConstraints for A {
-            fn check_constraints(_any: &Any) -> crate::Result<()> {
-                Ok(())
-            }
-        }
-        impl<'a> TryFrom<Any<'a>> for A {
-            type Error = MyError;
-
-            fn try_from(_value: Any<'a>) -> Result<Self, Self::Error> {
-                Ok(A)
-            }
-        }
-        impl DerAutoDerive for A {}
-
-        impl From<crate::Error> for MyError {
-            fn from(_value: crate::Error) -> Self {
-                Self
-            }
-        }
-
-        let res = A::from_der(&hex!("02 01 00"));
-        assert!(res.is_ok());
+    #[test]
+    fn debug_from_der_string_fail() {
+        // wrong charset
+        let input = &hex!("12 03 41 42 43");
+        let _ = NumericString::from_der(input).expect_err("parsing should fail");
     }
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,0 +1,178 @@
+use crate::ParseResult;
+
+#[macro_export]
+macro_rules! debug_eprintln {
+    ($msg: expr, $( $args:expr ),* ) => {
+        #[cfg(feature = "debug")]
+        {
+            let s = $msg.to_string().green();
+            eprintln!("{} {}", s, format!($($args),*));
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! trace_eprintln {
+    ($msg: expr, $( $args:expr ),* ) => {
+        #[cfg(feature = "trace")]
+        {
+            let s = $msg.to_string().green();
+            eprintln!("{} {}", s, format!($($args),*));
+        }
+    };
+}
+
+#[cfg(feature = "debug")]
+fn eprintln_hex_dump(bytes: &[u8], max_len: usize) {
+    use core::cmp::min;
+    use nom::HexDisplay;
+
+    let m = min(bytes.len(), max_len);
+    eprint!("{}", &bytes[..m].to_hex(16));
+    if bytes.len() > max_len {
+        eprintln!("... <continued>");
+    }
+}
+
+#[cfg(not(feature = "debug"))]
+#[inline]
+pub fn trace<'a, T, E, F>(_msg: &str, f: F, input: &'a [u8]) -> ParseResult<'a, T, E>
+where
+    F: Fn(&'a [u8]) -> ParseResult<'a, T, E>,
+{
+    f(input)
+}
+
+#[cfg(feature = "debug")]
+pub fn trace<'a, T, E, F>(msg: &str, f: F, input: &'a [u8]) -> ParseResult<'a, T, E>
+where
+    F: Fn(&'a [u8]) -> ParseResult<'a, T, E>,
+    E: core::fmt::Debug,
+{
+    use colored::Colorize;
+
+    trace_eprintln!(
+        msg,
+        "⤷ input (len={}, type={})",
+        input.len(),
+        core::any::type_name::<T>()
+    );
+    let res = f(input);
+    match &res {
+        Ok((_rem, _)) => {
+            trace_eprintln!(
+                msg,
+                "⤶ Parsed {} bytes, {} remaining",
+                input.len() - _rem.len(),
+                _rem.len()
+            );
+        }
+        Err(e) => {
+            debug_eprintln!(msg, "↯ Parsing failed: {}", e.to_string().red());
+            eprintln_hex_dump(input, 16);
+        }
+    }
+    res
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Any, FromDer};
+    use hex_literal::hex;
+
+    #[cfg(feature = "debug")]
+    #[test]
+    fn debug_from_der_any() {
+        assert!(Any::from_der(&hex!("01 01 ff")).is_ok());
+    }
+
+    #[cfg(feature = "debug")]
+    #[test]
+    fn debug_from_der_failures() {
+        use crate::Sequence;
+
+        // parsing any failed
+        eprintln!("--");
+        assert!(u16::from_der(&hex!("ff 00")).is_err());
+        // Indefinite length
+        eprintln!("--");
+        assert!(u16::from_der(&hex!("30 80 00 00")).is_err());
+        // DER constraints failed
+        eprintln!("--");
+        assert!(bool::from_der(&hex!("01 01 7f")).is_err());
+        // Incomplete sequence
+        eprintln!("--");
+        let _ = Sequence::from_der(&hex!("30 81 04 00 00"));
+    }
+
+    #[cfg(feature = "debug")]
+    #[test]
+    fn debug_from_der_sequence() {
+        // parsing OK, recursive
+        let input = &hex!("30 05 02 03 01 00 01");
+        let (rem, result) = <Vec<u32>>::from_der(input).expect("parsing failed");
+        assert_eq!(&result, &[65537]);
+        assert_eq!(rem, &[]);
+    }
+
+    #[cfg(feature = "debug")]
+    #[test]
+    fn debug_from_der_sequence_of() {
+        use crate::SequenceOf;
+        // parsing failure (wrong type)
+        let input = &hex!("30 03 01 01 00");
+        eprintln!("--");
+        let _ = <SequenceOf<u32>>::from_der(input).expect_err("parsing should fail");
+        eprintln!("--");
+        let _ = <Vec<u32>>::from_der(input).expect_err("parsing should fail");
+    }
+
+    #[cfg(feature = "debug")]
+    #[test]
+    fn debug_from_der_set_of() {
+        use crate::SetOf;
+        use alloc::collections::BTreeSet;
+
+        // parsing failure (wrong type)
+        let input = &hex!("31 03 01 01 00");
+        eprintln!("--");
+        let _ = <SetOf<u32>>::from_der(input).expect_err("parsing should fail");
+        eprintln!("--");
+        let _ = <BTreeSet<u32>>::from_der(input).expect_err("parsing should fail");
+    }
+
+    /// Check that it is possible to implement an error without fmt::Debug
+    #[cfg(not(feature = "debug"))]
+    #[test]
+    fn from_der_error_not_impl_debug() {
+        use crate::{CheckDerConstraints, DerAutoDerive};
+        use core::convert::TryFrom;
+
+        struct MyError;
+
+        struct A;
+
+        impl CheckDerConstraints for A {
+            fn check_constraints(_any: &Any) -> crate::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> TryFrom<Any<'a>> for A {
+            type Error = MyError;
+
+            fn try_from(_value: Any<'a>) -> Result<Self, Self::Error> {
+                Ok(A)
+            }
+        }
+        impl DerAutoDerive for A {}
+
+        impl From<crate::Error> for MyError {
+            fn from(_value: crate::Error) -> Self {
+                Self
+            }
+        }
+
+        let res = A::from_der(&hex!("02 01 00"));
+        assert!(res.is_ok());
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use crate::{Class, Tag};
 use alloc::str;
 use alloc::string;
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 use displaydoc::Display;
 use nom::error::{ErrorKind, FromExternalError, ParseError};

--- a/src/error.rs
+++ b/src/error.rs
@@ -90,7 +90,7 @@ pub enum Error {
     /// Invalid Date or Time
     InvalidDateTime,
 
-    /// DER Failed constraint
+    /// DER Failed constraint: {0:?}
     DerConstraintFailed(DerConstraint),
 
     /// Requesting borrowed data from a temporary object

--- a/src/header.rs
+++ b/src/header.rs
@@ -248,17 +248,17 @@ impl<'a> FromBer<'a> for Header<'a> {
             (_, l1) => {
                 // if len is 0xff -> error (8.1.3.5)
                 if l1 == 0b0111_1111 {
-                    return Err(::nom::Err::Error(Error::InvalidLength));
+                    return Err(nom::Err::Error(Error::InvalidLength));
                 }
                 let (i3, llen) = take(l1)(i2)?;
                 match bytes_to_u64(llen) {
                     Ok(l) => {
                         let l =
-                            usize::try_from(l).or(Err(::nom::Err::Error(Error::InvalidLength)))?;
+                            usize::try_from(l).or(Err(nom::Err::Error(Error::InvalidLength)))?;
                         (i3, Length::Definite(l))
                     }
                     Err(_) => {
-                        return Err(::nom::Err::Error(Error::InvalidLength));
+                        return Err(nom::Err::Error(Error::InvalidLength));
                     }
                 }
             }
@@ -284,14 +284,14 @@ impl<'a> FromDer<'a> for Header<'a> {
             }
             (_, 0) => {
                 // Indefinite form is not allowed in DER (10.1)
-                return Err(::nom::Err::Error(Error::DerConstraintFailed(
+                return Err(nom::Err::Error(Error::DerConstraintFailed(
                     DerConstraint::IndefiniteLength,
                 )));
             }
             (_, l1) => {
                 // if len is 0xff -> error (8.1.3.5)
                 if l1 == 0b0111_1111 {
-                    return Err(::nom::Err::Error(Error::InvalidLength));
+                    return Err(nom::Err::Error(Error::InvalidLength));
                 }
                 // DER(9.1) if len is 0 (indefinite form), obj must be constructed
                 der_constraint_fail_if!(
@@ -305,11 +305,11 @@ impl<'a> FromDer<'a> for Header<'a> {
                         // DER: should have been encoded in short form (< 127)
                         // XXX der_constraint_fail_if!(i, l < 127);
                         let l =
-                            usize::try_from(l).or(Err(::nom::Err::Error(Error::InvalidLength)))?;
+                            usize::try_from(l).or(Err(nom::Err::Error(Error::InvalidLength)))?;
                         (i3, Length::Definite(l))
                     }
                     Err(_) => {
-                        return Err(::nom::Err::Error(Error::InvalidLength));
+                        return Err(nom::Err::Error(Error::InvalidLength));
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,7 @@ mod asn1_types;
 mod ber;
 mod class;
 mod datetime;
+mod debug;
 mod derive;
 mod error;
 mod header;

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -1,4 +1,5 @@
 use crate::{Error, Result};
+#[cfg(not(feature = "std"))]
 use alloc::string::ToString;
 use rusticata_macros::newtype_enum;
 

--- a/tests/der.rs
+++ b/tests/der.rs
@@ -206,6 +206,18 @@ fn from_der_null() {
 }
 
 #[test]
+fn from_der_numericstring() {
+    //
+    let input = &hex!("12 03 31 32 33");
+    let (rem, result) = NumericString::from_der(input).expect("parsing failed");
+    assert_eq!(result.as_ref(), "123");
+    assert_eq!(rem, &[]);
+    // wrong charset
+    let input = &hex!("12 03 41 42 43");
+    let _ = NumericString::from_der(input).expect_err("parsing should fail");
+}
+
+#[test]
 fn from_der_octetstring() {
     // coverage
     use std::borrow::Cow;


### PR DESCRIPTION
These features allow tracing (printing everything) or debugging (printing only errors) BER/DER parsers.