### PR TITLE
ci: add github-actions ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/target
 Cargo.lock
+/.idea


### PR DESCRIPTION
:wave: It looks like you beat me to this repo for the majority of the CI update tasks. Thanks! 

The only omission I noticed that might be worthwhile was configuring dependabot for github actions updates  If you wanted to avoid that on purpose for some reason that's OK too, please close as required.