### PR TITLE
Update cargo-check-external-types rustc version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-02-07
+          toolchain: nightly-2024-05-01
           # ^ sync with https://github.com/awslabs/cargo-check-external-types/blob/main/rust-toolchain.toml
       - run: cargo install cargo-check-external-types
       - run: cargo check-external-types


### PR DESCRIPTION
:wave: As promised, when `cargo-check-external-types` makes an update I'm opening PRs to fix the builds :-)

Note: there seems to be another unrelated breakage with nightly clippy, a finding from [unexpected-cfgs](https://doc.rust-lang.org/nightly/rustc/lints/listing/warn-by-default.html#unexpected-cfgs). I'm not sure what the right fix is in this case: it seems like "exact_size_is_empty" is being used as a feature gate for the unstable nightly feature (https://github.com/rust-lang/rust/issues/35428) and I'm not sure how to square that requirement with the new lint. Suggestions welcome!