### PR TITLE
fix unsigned

### DIFF
--- a/src/asn1_types/integer.rs
+++ b/src/asn1_types/integer.rs
@@ -41,9 +41,6 @@ fn trim_slice(bytes: &[u8]) -> &[u8] {
 /// Decode an unsigned integer into a byte array of the requested size
 /// containing a big endian integer.
 fn decode_array_uint<const N: usize>(bytes: &[u8]) -> Result<[u8; N]> {
-    if is_highest_bit_set(bytes) {
-        return Err(Error::IntegerNegative);
-    }
     let input = trim_slice(bytes);
 
     if input.len() > N {


### PR DESCRIPTION
If a Counter64 has 1 in the first bit, an IntegerNegative error is raised. For unsigned values, this check is not needed. The bug is in the decode_array_uint function — why check the first bit for an unsigned value?